### PR TITLE
micro optimization, moved Array Prototype lookup outside of function

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,11 @@ module.exports = thunkify;
  * @api public
  */
 
+var arr_cast = Array.prototype.slice;
+
 function thunkify(fn){
   return function(){
-    var args = [].slice.call(arguments);
+    var args = arr_cast.call(arguments);
     var results;
     var called;
     var cb;


### PR DESCRIPTION
Because of the nature of the library, you may want to accept a minor revision for speed,

var BM = require('benchmark');

var apslice = Array.prototype.slice;
var f1 = function () { apslice.call(arguments) };
var f2 = function () { [].slice.call(arguments) };

var suite = new BM.Suite;

suite.add('f1', f1).add('f2', f2)
  .on('cycle', function(event) {
    console.log(String(event.target));
  })
  .on('complete', function() {
    console.log('Fastest is ', this.filter('fastest').pluck('name') );
  })
  .run({async:false});
