### PR TITLE
add ability to pass different context

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ module.exports = thunkify;
  * @api public
  */
 
-function thunkify(fn){
+function thunkify(fn, ctx){
   assert('function' == typeof fn, 'function required');
 
   return function(){
     var args = new Array(arguments.length);
-    var ctx = this;
+    ctx || (ctx = this);
 
     for(var i = 0; i < args.length; ++i) {
       args[i] = arguments[i];

--- a/test/index.js
+++ b/test/index.js
@@ -108,4 +108,23 @@ describe('thunkify(fn)', function(){
       });
     });
   })
+
+  it('should preserve passed context', function(done){
+    function Foo() { 
+      this.bar = 'bar';
+      this.fn = function (callback) {
+        callback(null, this.bar);
+      }
+    }
+  
+    var foo = new Foo();
+    
+    fn = thunkify(foo.fn, foo);
+
+    fn()(function (err, a) {
+      assert('bar' == a);
+      done();
+    });
+  })
+
 })


### PR DESCRIPTION
I ran into situation where I had to apply `thunkify` to function executed from different context. The alternative here could be to just run: `thunkify(fn).bind(ctx)` but it would be convenient to just pass it as an argument ;) 
