### PR TITLE
Add prototype

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,10 +18,20 @@ var fs = require('fs');
 var read = thunkify(fs.readFile);
 
 read('package.json', 'utf8')(function(err, str){
-  
+
 });
 ```
+### Or
+```js
+var thunkify = require('thunkify');
+var fs = require('fs');
 
+thunkify.addProto();
+
+read.thunkify('package.json', 'utf8')(function(err, str){
+
+});
+```
 # License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -12,6 +12,18 @@ var assert = require('assert');
 module.exports = thunkify;
 
 /**
+* export prototype method
+*/
+thunkify.addProto = function () {
+
+Object.defineProperty(Function.prototype, "thunkify", {
+  get: function () {
+    return thunkify(this);
+  }
+});
+};
+
+/**
  * Wrap a regular callback `fn` as a thunk.
  *
  * @param {Function} fn


### PR DESCRIPTION
This makes a code shorter in big projects, where we can't create vars for every functions. IMHO